### PR TITLE
Removed ox_inventory dependency

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,7 +20,3 @@ shared_scripts {
   '@ox_lib/init.lua',
   'config.lua'
 }
-
-dependencies {
-  'ox_inventory'
-}


### PR DESCRIPTION
I removed it as it force starts the inventory before wasabi_backpack for me. The problem is that dependency is requesting the resource to start if not started yet. I have this problem, don't know if anyone else too.